### PR TITLE
Use distro supplied rabbitmq

### DIFF
--- a/scripts/rabbitmq/erl
+++ b/scripts/rabbitmq/erl
@@ -1,0 +1,29 @@
+#!/bin/sh
+#
+# %CopyrightBegin%
+# 
+# Copyright Ericsson AB 1996-2012. All Rights Reserved.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+# %CopyrightEnd%
+#
+ROOTDIR=$SNAP/usr/lib/erlang
+BINDIR=$ROOTDIR/erts-7.3/bin
+EMU=beam
+PROGNAME=`echo $0 | sed 's/.*\///'`
+export EMU
+export ROOTDIR
+export BINDIR
+export PROGNAME
+exec "$BINDIR/erlexec" ${1+"$@"}

--- a/scripts/rabbitmq/rabbitmq-defaults
+++ b/scripts/rabbitmq/rabbitmq-defaults
@@ -1,0 +1,39 @@
+#!/bin/sh -ex
+##  The contents of this file are subject to the Mozilla Public License
+##  Version 1.1 (the "License"); you may not use this file except in
+##  compliance with the License. You may obtain a copy of the License
+##  at http://www.mozilla.org/MPL/
+##
+##  Software distributed under the License is distributed on an "AS IS"
+##  basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See
+##  the License for the specific language governing rights and
+##  limitations under the License.
+##
+##  The Original Code is RabbitMQ.
+##
+##  The Initial Developer of the Original Code is GoPivotal, Inc.
+##  Copyright (c) 2012-2015 Pivotal Software, Inc.  All rights reserved.
+##
+
+### next line potentially updated in package install steps
+SYS_PREFIX=$SNAP_COMMON
+
+### next line will be updated when generating a standalone release
+ERL_DIR=
+
+CLEAN_BOOT_FILE=start_clean
+SASL_BOOT_FILE=start_sasl
+
+## Set default values
+
+BOOT_MODULE="rabbit"
+
+CONFIG_FILE=${SYS_PREFIX}/etc/rabbitmq/rabbitmq
+LOG_BASE=${SYS_PREFIX}/log/rabbitmq
+MNESIA_BASE=${SYS_PREFIX}/lib/rabbitmq/mnesia
+ENABLED_PLUGINS_FILE=${SYS_PREFIX}/etc/rabbitmq/enabled_plugins
+
+PLUGINS_DIR="${RABBITMQ_HOME}/plugins"
+IO_THREAD_POOL_SIZE=64
+
+CONF_ENV_FILE=${SYS_PREFIX}/etc/rabbitmq/rabbitmq-env.conf

--- a/scripts/rabbitmq/rabbitmq-script-wrapper
+++ b/scripts/rabbitmq/rabbitmq-script-wrapper
@@ -1,0 +1,33 @@
+#!/bin/sh
+##  The contents of this file are subject to the Mozilla Public License
+##  Version 1.1 (the "License"); you may not use this file except in
+##  compliance with the License. You may obtain a copy of the License
+##  at http://www.mozilla.org/MPL/
+##
+##  Software distributed under the License is distributed on an "AS IS"
+##  basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See
+##  the License for the specific language governing rights and
+##  limitations under the License.
+##
+##  The Original Code is RabbitMQ.
+##
+##  The Initial Developer of the Original Code is GoPivotal, Inc.
+##  Copyright (c) 2007-2014 GoPivotal, Inc.  All rights reserved.
+##
+
+mkdir -p $SNAP_COMMON/lib/rabbitmq
+cd $SNAP_COMMON/lib/rabbitmq
+
+SCRIPT=`basename $0`
+
+case $SCRIPT in
+    rabbitmq-server)
+        mkdir -p $SNAP_COMMON/log/rabbitmq
+        $SNAP/usr/lib/rabbitmq/bin/rabbitmq-server "$@" \
+            > "$SNAP_COMMON/log/rabbitmq/startup_log" \
+            2> "$SNAP_COMMON/log/rabbitmq/startup_err"
+    ;;
+    *)
+        $SNAP/usr/lib/rabbitmq/bin/${SCRIPT} "$@"
+    ;;
+esac

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -165,24 +165,22 @@ apps:
 
   # RabbitMQ
   rabbitmq-server:
-    command: lib/erlang/lib/rabbitmq_server/sbin/rabbitmq-server
+    command: rabbitmq-server
     daemon: simple
     plugs:
       - network-bind
+    environment:
+      HOME: $SNAP_COMMON/lib/rabbitmq
   rabbitmqctl:
-    command: lib/erlang/lib/rabbitmq_server/sbin/rabbitmqctl
+    command: rabbitmqctl
     plugs:
       - network
+    environment:
+      HOME: $SNAP_COMMON/lib/rabbitmq
   rabbitmq-plugins:
-    command: lib/erlang/lib/rabbitmq_server/sbin/rabbitmq-plugins
-  rabbitmq-defaults:
-    command: lib/erlang/lib/rabbitmq_server/sbin/rabbitmq-defaults
-  rabbitmq-env:
-    command: lib/erlang/lib/rabbitmq_server/sbin/rabbitmq-env
-  erl:
-    command: bin/erl
-  escript:
-    command: bin/escript
+    command: rabbitmq-plugins
+    environment:
+      HOME: $SNAP_COMMON/lib/rabbitmq
 
   # Memcached
   memcached:
@@ -582,55 +580,22 @@ parts:
       mysql-start-client: bin/mysql-start-client
       mysql-startup: bin/mysql-startup
 
-  # RabbitMQ
-  erlang:
-    source: http://www.erlang.org/download/otp_src_21.1.tar.gz
-    plugin: make
-    build-packages:
-      - gcc
-      - make
-      - libncurses5-dev
-      - libssl-dev
-      - curl
+  # RabbitMQa
+  rabbitmq-server:
+    source: ./scripts/rabbitmq
+    plugin: dump
+    stage-packages:
+      - rabbitmq-server
     override-build: |
-      export ERL_TOP=$SNAPCRAFT_PART_BUILD
-      ./configure --with-ssl --prefix=$SNAPCRAFT_PART_INSTALL
-      make
-      make install
-
-  elixir:
-    after: [erlang]
-    source: https://github.com/elixir-lang/elixir/archive/v1.7.3.tar.gz
-    plugin: make
-    override-build: |
-      export PREFIX=$SNAPCRAFT_PART_INSTALL
-      make
-      make install
-
-  rabbitmq-server-release:
-    after: [elixir]
-    source: https://github.com/rabbitmq/rabbitmq-server-release.git
-    plugin: make
-    override-build: |
-      make source-dist
-      cp PACKAGES/rabbitmq*.tar.xz $SNAPCRAFT_PART_INSTALL/rabbitmq-server.tar.xz
-  rabbitmq:
-    after: [rabbitmq-server-release]
-    source: ./parts/rabbitmq-server-release/install/rabbitmq-server.tar.xz
-    plugin: make
-    build-packages:
-      - python2.7
-      - libxslt1-dev
-      - xmlto
-      - zip
-      - unzip
-    override-build: |
-      export PREFIX=$SNAPCRAFT_PART_INSTALL
-      export RMQ_ROOTDIR=$PREFIX/lib/erlang
-      export RMQ_LIBDIR=$RMQ_ROOTDIR/lib
-      export RMQ_ERLAPP_DIR=$RMQ_LIBDIR/rabbitmq_server
-      make
-      make install
+      rm -f $SNAPCRAFT_PART_INSTALL/usr/bin/erl
+      rm -f $SNAPCRAFT_PART_INSTALL/usr/lib/rabbitmq/bin/rabbitmq-script-wrapper
+      # NOTE(jamespage): The versioned path below is brittle.
+      rm -f $SNAPCRAFT_PART_INSTALL/usr/lib/rabbitmq/lib/rabbitmq_server-3.5.7/sbin/rabbitmq-defaults
+      snapcraftctl build
+    organize:
+      rabbitmq-script-wrapper: usr/lib/rabbitmq/bin/rabbitmq-script-wrapper
+      rabbitmq-defaults: usr/lib/rabbitmq/lib/rabbitmq_server-3.5.7/sbin/rabbitmq-defaults
+      erl: usr/bin/erl
 
   # Memcached
   memcached:


### PR DESCRIPTION
This requires a little bit of munging of the startup scripts to:

a) Allow RMQ to run as root.
b) Massage the default env vars for rmq and erlang to point
   to snap locations.