### PR TITLE
Avoid getting to "(try 4 of 3)" tries to build the instance

### DIFF
--- a/src/launch/launch.sh
+++ b/src/launch/launch.sh
@@ -34,10 +34,10 @@ fi
 
 TRIES=0
 while [[ $(openstack server list | grep $SERVER | grep ERROR) ]]; do
+    TRIES=$(($TRIES + 1))
     if test $TRIES -gt 3; then
         break
     fi
-    TRIES=$(($TRIES + 1))
     echo "I ran into an issue launching an instance. Retrying ... (try $TRIES of 3)"
     openstack server delete $SERVER
     openstack server create --flavor m1.tiny --image cirros --nic net-id=test --key-name microstack $SERVER


### PR DESCRIPTION
In trying to use launch.sh I saw
```
I ran into an issue launching an instance. Retrying ... (try 4 of 3)
```
this is a tiny fix to that.