### PR TITLE
Fixed openvswitch timeout issue.

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -177,6 +177,8 @@ apps:
   ovs-vswitchd:
     command: ovs-wrapper $SNAP/share/openvswitch/scripts/ovs-ctl --no-ovsdb-server --no-monitor --system-id=random start
     stop-command: ovs-wrapper $SNAP/share/openvswitch/scripts/ovs-ctl --no-ovsdb-server stop
+    passthrough:
+      after: [ovsdb-server]
     daemon: forking
 #    plugs:
 #      - network
@@ -602,8 +604,8 @@ parts:
       - --target-list=x86_64-softmmu
     override-build: |
       wget http://archive.ubuntu.com/ubuntu/pool/main/q/qemu/qemu_2.5+dfsg.orig.tar.xz
-      wget http://archive.ubuntu.com/ubuntu/pool/main/q/qemu/qemu_2.5+dfsg-5ubuntu10.32.debian.tar.xz
-      wget http://archive.ubuntu.com/ubuntu/pool/main/q/qemu/qemu_2.5+dfsg-5ubuntu10.32.dsc
+      wget http://archive.ubuntu.com/ubuntu/pool/main/q/qemu/qemu_2.5+dfsg-5ubuntu10.33.debian.tar.xz
+      wget http://archive.ubuntu.com/ubuntu/pool/main/q/qemu/qemu_2.5+dfsg-5ubuntu10.33.dsc
       dpkg-source -x qemu_*.dsc
       snapcraftctl build
     organize:


### PR DESCRIPTION
It appeared to merely be an issue of ensuring that the daemon started before the server.

Also the version on one of the files that we download for another serivce. (Fragile code is still fragile, but fixing it is a separate TODO.)

Addresses https://github.com/CanonicalLtd/microstack/issues/42