### PR TITLE
Fixed issue w/ network going away after reboot.

### DIFF
--- a/snap-wrappers/neutron/neutron-server-wrapper
+++ b/snap-wrappers/neutron/neutron-server-wrapper
@@ -1,0 +1,21 @@
+#!/bin/bash
+#
+# Wrapper script for neutron-server and openvswitch networking.
+#
+# Creates br-ex, and sets up an ip address for it. We put this in a
+# wrapper so that the ip address persists after reboot, without
+# needing to add networking entries to the host system. (We want this
+# to work well when we turn off classic confinement.)
+
+set -ex
+
+# Create external integration bridge
+ovs-vsctl --retry --may-exist add-br br-ex
+
+# Configure br-ex
+ip address add 10.20.20.1/24 dev br-ex || :
+ip link set br-ex up || :
+
+while ! nc -z localhost 9292; do sleep 0.1; done;
+
+snap-openstack neutron-server

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -33,18 +33,9 @@ HOME=$SNAP_COMMON/lib/rabbitmq rabbitmqctl set_permissions openstack ".*" ".*" "
 # Open vSwitch/Neutron
 echo "Configuring Open vSwitch networking"
 
-# Create external integration bridge
-ovs-vsctl --retry --may-exist add-br br-ex
-
-# Configure br-ex
-ip address add 10.20.20.1/24 dev br-ex || :
-ip link set br-ex up || :
-
-while ! nc -z localhost 9292; do sleep 0.1; done;
-
+# Wait for identity service
 sleep 5
 
-# Wait for identity service
 while ! nc -z localhost 5000; do sleep 0.1; done;
 
 openstack image show cirros || {

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -89,7 +89,7 @@ apps:
 
   # Neutron
   neutron-api:
-    command: snap-openstack neutron-server
+    command: neutron-server-wrapper
     daemon: simple
 #    plugs:
 #      - network-bind
@@ -346,6 +346,14 @@ parts:
       # This is the last step, let's now compile all our pyc files.
       # Ignore errors due to syntax issues in foobar python 2.
       ./usr/bin/python2.7 -m compileall . || true
+
+  neutron-wrapper:
+    source: ./snap-wrappers/neutron
+    plugin: dump
+    after:
+      - openstack-projects
+    organize:
+      neutron-server-wrapper: bin/neutron-server-wrapper
 
   keystone-config:
     after: [openstack-projects]


### PR DESCRIPTION
We weren't creating a netplan config and/or and entry in /etc/network/interfaces for br-ex.

Since we don't actually want to touch the host system, I added a wrapper around neutron-server that sets up a transient br-ex before the neutron-server daemon starts. This addresses the issue in a lightweight way that will automatically clean itself up after the snap is uninstalled and the host reboots.