### PR TITLE
Perist external bridge over reboots.

### DIFF
--- a/snap-overlay/bin/setup-br-ex
+++ b/snap-overlay/bin/setup-br-ex
@@ -1,0 +1,19 @@
+#!/bin/bash
+#
+# Oneshot daemon which creates a networking bridge.
+#
+# Creates br-ex, and sets up an ip address for it. We put this in a
+# oneshot so that the ip address persists after reboot, without
+# needing to add networking entries to the host system. (We want this
+# to work well when we turn off classic confinement.)
+
+set -ex
+
+# Create external integration bridge
+ovs-vsctl --retry --may-exist add-br br-ex
+
+# Configure br-ex
+ip address add 10.20.20.1/24 dev br-ex || :
+ip link set br-ex up || :
+
+exit 0

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -30,16 +30,8 @@ done
 HOME=$SNAP_COMMON/lib/rabbitmq rabbitmqctl add_user openstack rabbitmq || :
 HOME=$SNAP_COMMON/lib/rabbitmq rabbitmqctl set_permissions openstack ".*" ".*" ".*"
 
-# Open vSwitch/Neutron
-echo "Configuring Open vSwitch networking"
-
-# Create external integration bridge
-ovs-vsctl --retry --may-exist add-br br-ex
-
-# Configure br-ex
-ip address add 10.20.20.1/24 dev br-ex || :
-ip link set br-ex up || :
-
+# Glance
+echo "Waiting for glance to start."
 while ! nc -z localhost 9292; do sleep 0.1; done;
 
 sleep 5

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -215,6 +215,14 @@ apps:
 #    plugs:
 #      - network
 
+  external-bridge:
+    command: bin/setup-br-ex
+    daemon: oneshot
+    passthrough:
+      after: [ovs-vswitchd]
+#    plugs:
+#      - network
+
   # Libvirt/Qemu
   libvirtd:
     command: libvirtd


### PR DESCRIPTION
This fixes an issue where we weren't creating a netplan config and/or
and entry in /etc/network/interfaces for br-ex, and thus losing
external access to our virtual networks after reboot.

Since we don't actually want to touch the host system's networking
config, we just drop a oneshot daemon into place that sets br-ex up
each time the snap services are started.