### PR TITLE
Switched to qemu and host-model libvirt settings.

### DIFF
--- a/snap-overlay/etc/nova/nova.conf.d/hypervisor.conf
+++ b/snap-overlay/etc/nova/nova.conf.d/hypervisor.conf
@@ -5,5 +5,5 @@ compute_driver = libvirt.LibvirtDriver
 disable_rootwrap = True
 
 [libvirt]
-virt_type = kvm
-cpu_mode = host-passthrough
+virt_type = qemu
+cpu_mode = host-model


### PR DESCRIPTION
These settings are less performant, but more universally compatible.

A seperate task would be to expose these settings via the snap config,
in some sensible way. For now, this means that microstack will "just
work" in more places.

@javacruft 