### PR TITLE
Disabled themes.

### DIFF
--- a/snap-overlay/lib/python2.7/site-packages/openstack_dashboard/local/local_settings.d/_05_snap_tweaks.py
+++ b/snap-overlay/lib/python2.7/site-packages/openstack_dashboard/local/local_settings.d/_05_snap_tweaks.py
@@ -10,3 +10,14 @@ SECRET_KEY = "overridethis!"
 # compression off (either a bug or something that I'm not
 # understanding). Tell it to write them some place writeable.
 STATIC_ROOT = '/var/snap/microstack/common/var/horizon/static'
+
+# Disable extra themes for now. TODO: Re-enable when
+# https://github.com/CanonicalLtd/microstack/issues/39 is
+# addressed. (You'll need to uncomment the material theme below when testing
+# the fix.)
+AVAILABLE_THEMES = [
+    ('default', 'Default', 'themes/default'),
+#    ('material', 'Material', 'themes/material'),
+]
+
+ 


### PR DESCRIPTION
This is a bandaid for
https://github.com/CanonicalLtd/microstack/issues/39, where switching
to the material theme can get your GUI stuck in an errored
state. We'll re-enable everything once that bug is fixed.