### PR TITLE
Added iptables rules and sysctl vars for internet access

### DIFF
--- a/snap-overlay/bin/setup-br-ex
+++ b/snap-overlay/bin/setup-br-ex
@@ -16,4 +16,6 @@ ovs-vsctl --retry --may-exist add-br br-ex
 ip address add 10.20.20.1/24 dev br-ex || :
 ip link set br-ex up || :
 
+sudo iptables -t nat -A POSTROUTING -s 10.20.20.1/24 ! -d 10.20.20.1/24 -j MASQUERADE
+
 exit 0

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -1,5 +1,10 @@
 #!/bin/bash -e
 
+# Open up networking so that instances can route to the Internet (see
+# bin/setup-br-ex for more networking setup, executed on microstack
+# services start.)
+sudo sysctl net.ipv4.ip_forward=1
+
 # Create all of the databases
 echo "Creating OpenStack Databases"
 

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -691,8 +691,8 @@ parts:
     - IPTABLES_PATH=/snap/$SNAPCRAFT_PROJECT_NAME/current/sbin/iptables
     override-build: |
       wget http://archive.ubuntu.com/ubuntu/pool/main/libv/libvirt/libvirt_1.3.1.orig.tar.gz
-      wget http://archive.ubuntu.com/ubuntu/pool/main/libv/libvirt/libvirt_1.3.1-1ubuntu10.24.debian.tar.xz
-      wget http://archive.ubuntu.com/ubuntu/pool/main/libv/libvirt/libvirt_1.3.1-1ubuntu10.24.dsc
+      wget http://archive.ubuntu.com/ubuntu/pool/main/libv/libvirt/libvirt_1.3.1-1ubuntu10.25.debian.tar.xz
+      wget http://archive.ubuntu.com/ubuntu/pool/main/libv/libvirt/libvirt_1.3.1-1ubuntu10.25.dsc
       dpkg-source -x libvirt*.dsc
       snapcraftctl build
     organize:


### PR DESCRIPTION
Fixes lp#1812415

Prior to this fix, instances spun up by microstack could not
successfully route to and from the Internet. Setting a rule for ipv4
forwarding and iptables rules for the nat fix the issue.