### PR TITLE
Bug/1823179 no longer use localhost

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ To quickly configure networks and launch a vm, run `microstack.launch`.
 
 This will launch an instance for you, and make it available to manage via the command line, or via the Horizon Dashboard.
 
-To access the Dashboard, visit http://localhost in a web browser, and login with the following credentials:
+To access the Dashboard, visit http://10.20.20.1 in a web browser, and login with the following credentials:
 
 ```
 username: admin

--- a/snap-overlay/bin/configure-openstack
+++ b/snap-overlay/bin/configure-openstack
@@ -11,9 +11,9 @@ systemctl restart snap.microstack.keystone-*
 openstack user show admin || {
     snap-openstack keystone-manage bootstrap \
         --bootstrap-password $OS_PASSWORD \
-        --bootstrap-admin-url http://localhost:5000/v3/ \
-        --bootstrap-internal-url http://localhost:5000/v3/ \
-        --bootstrap-public-url http://localhost:5000/v3/ \
+        --bootstrap-admin-url http://10.20.20.1:5000/v3/ \
+        --bootstrap-internal-url http://10.20.20.1:5000/v3/ \
+        --bootstrap-public-url http://10.20.20.1:5000/v3/ \
         --bootstrap-region-id microstack
 }
 
@@ -40,7 +40,7 @@ openstack service show compute || {
 
     for endpoint in public internal admin; do
         openstack endpoint create --region microstack \
-          compute $endpoint http://localhost:8774/v2.1 || :
+          compute $endpoint http://10.20.20.1:8774/v2.1 || :
     done
 }
 
@@ -50,7 +50,7 @@ openstack service show placement || {
 
     for endpoint in public internal admin; do
         openstack endpoint create --region microstack \
-          placement $endpoint http://localhost:8778 || :
+          placement $endpoint http://10.20.20.1:8778 || :
     done
 }
 
@@ -65,7 +65,7 @@ snap-openstack nova-manage db sync
 
 systemctl restart snap.microstack.nova-*
 
-while ! nc -z localhost 8774; do sleep 0.1; done;
+while ! nc -z 10.20.20.1 8774; do sleep 0.1; done;
 
 sleep 5
 
@@ -99,7 +99,7 @@ openstack service show network || {
 
     for endpoint in public internal admin; do
         openstack endpoint create --region microstack \
-          network $endpoint http://localhost:9696 || :
+          network $endpoint http://10.20.20.1:9696 || :
     done
 }
 
@@ -107,7 +107,7 @@ snap-openstack neutron-db-manage upgrade head
 
 systemctl restart snap.microstack.neutron-*
 
-while ! nc -z localhost 9696; do sleep 0.1; done;
+while ! nc -z 10.20.20.1 9696; do sleep 0.1; done;
 
 sleep 5
 
@@ -148,7 +148,7 @@ openstack service show image || {
     openstack service create --name glance --description "OpenStack Image" image
     for endpoint in internal admin public; do
         openstack endpoint create --region microstack \
-            image $endpoint http://localhost:9292 || :
+            image $endpoint http://10.20.20.1:9292 || :
     done
 }
 
@@ -156,7 +156,7 @@ snap-openstack glance-manage db_sync
 
 systemctl restart snap.microstack.glance*
 
-while ! nc -z localhost 9292; do sleep 0.1; done;
+while ! nc -z 10.20.20.1 9292; do sleep 0.1; done;
 
 sleep 5
 

--- a/snap-overlay/etc/glance/glance.conf.d/database.conf
+++ b/snap-overlay/etc/glance/glance.conf.d/database.conf
@@ -1,2 +1,2 @@
 [database]
-connection = mysql+pymysql://glance:glance@localhost/glance
+connection = mysql+pymysql://glance:glance@10.20.20.1/glance

--- a/snap-overlay/etc/glance/glance.conf.d/keystone.conf
+++ b/snap-overlay/etc/glance/glance.conf.d/keystone.conf
@@ -1,7 +1,7 @@
 [keystone_authtoken]
-auth_uri = http://localhost:5000
-auth_url = http://localhost:5000
-memcached_servers = localhost:11211
+auth_uri = http://10.20.20.1:5000
+auth_url = http://10.20.20.1:5000
+memcached_servers = 10.20.20.1:11211
 auth_type = password
 project_domain_name = default
 user_domain_name = default

--- a/snap-overlay/etc/keystone/keystone.conf.d/database.conf
+++ b/snap-overlay/etc/keystone/keystone.conf.d/database.conf
@@ -1,2 +1,2 @@
 [database]
-connection = mysql+pymysql://keystone:keystone@localhost/keystone
+connection = mysql+pymysql://keystone:keystone@10.20.20.1/keystone

--- a/snap-overlay/etc/neutron/metadata_agent.ini
+++ b/snap-overlay/etc/neutron/metadata_agent.ini
@@ -1,3 +1,3 @@
 [DEFAULT]
-nova_metadata_ip = localhost
+nova_metadata_ip = 10.20.20.1
 metadata_proxy_shared_secret = supersecret

--- a/snap-overlay/etc/neutron/neutron.conf.d/database.conf
+++ b/snap-overlay/etc/neutron/neutron.conf.d/database.conf
@@ -1,2 +1,2 @@
 [database]
-connection = mysql+pymysql://neutron:neutron@localhost/neutron
+connection = mysql+pymysql://neutron:neutron@10.20.20.1/neutron

--- a/snap-overlay/etc/neutron/neutron.conf.d/keystone.conf
+++ b/snap-overlay/etc/neutron/neutron.conf.d/keystone.conf
@@ -2,9 +2,9 @@
 auth_strategy = keystone
 
 [keystone_authtoken]
-auth_uri = http://localhost:5000
-auth_url = http://localhost:5000
-memcached_servers = localhost:11211
+auth_uri = http://10.20.20.1:5000
+auth_url = http://10.20.20.1:5000
+memcached_servers = 10.20.20.1:11211
 auth_type = password
 project_domain_name = default
 user_domain_name = default

--- a/snap-overlay/etc/neutron/neutron.conf.d/nova.conf
+++ b/snap-overlay/etc/neutron/neutron.conf.d/nova.conf
@@ -3,7 +3,7 @@ notify_nova_on_port_status_changes = True
 notify_nova_on_port_data_changes = True
 
 [nova]
-auth_url = http://localhost:5000
+auth_url = http://10.20.20.1:5000
 auth_type = password
 project_domain_name = default
 user_domain_name = default

--- a/snap-overlay/etc/nova/nova.conf.d/database.conf
+++ b/snap-overlay/etc/nova/nova.conf.d/database.conf
@@ -1,5 +1,5 @@
 [database]
-connection = mysql+pymysql://nova:nova@localhost/nova
+connection = mysql+pymysql://nova:nova@10.20.20.1/nova
 
 [api_database]
-connection = mysql+pymysql://nova_api:nova_api@localhost/nova_api
+connection = mysql+pymysql://nova_api:nova_api@10.20.20.1/nova_api

--- a/snap-overlay/etc/nova/nova.conf.d/glance.conf
+++ b/snap-overlay/etc/nova/nova.conf.d/glance.conf
@@ -1,2 +1,2 @@
 [glance]
-api_servers = http://localhost:9292
+api_servers = http://10.20.20.1:9292

--- a/snap-overlay/etc/nova/nova.conf.d/keystone.conf
+++ b/snap-overlay/etc/nova/nova.conf.d/keystone.conf
@@ -1,7 +1,7 @@
 [keystone_authtoken]
-auth_uri = http://localhost:5000
-auth_url = http://localhost:5000
-memcached_servers = localhost:11211
+auth_uri = http://10.20.20.1:5000
+auth_url = http://10.20.20.1:5000
+memcached_servers = 10.20.20.1:11211
 auth_type = password
 project_domain_name = default
 user_domain_name = default

--- a/snap-overlay/etc/nova/nova.conf.d/neutron.conf
+++ b/snap-overlay/etc/nova/nova.conf.d/neutron.conf
@@ -1,7 +1,7 @@
 [neutron]
-url = http://localhost:9696
-auth_url = http://localhost:5000
-memcached_servers = localhost:11211
+url = http://10.20.20.1:9696
+auth_url = http://10.20.20.1:5000
+memcached_servers = 10.20.20.1:11211
 auth_type = password
 project_domain_name = default
 user_domain_name = default

--- a/snap-overlay/etc/nova/nova.conf.d/nova-placement.conf
+++ b/snap-overlay/etc/nova/nova.conf.d/nova-placement.conf
@@ -4,6 +4,6 @@ project_domain_name = default
 project_name = service
 auth_type = password
 user_domain_name = default
-auth_url = http://localhost:5000
+auth_url = http://10.20.20.1:5000
 username = placement
 password = placement

--- a/snap-overlay/etc/nova/nova.conf.d/rabbitmq.conf
+++ b/snap-overlay/etc/nova/nova.conf.d/rabbitmq.conf
@@ -1,2 +1,2 @@
 [DEFAULT]
-transport_url = rabbit://openstack:rabbitmq@localhost
+transport_url = rabbit://openstack:rabbitmq@10.20.20.1

--- a/snap-overlay/lib/python2.7/site-packages/openstack_dashboard/local/local_settings.py
+++ b/snap-overlay/lib/python2.7/site-packages/openstack_dashboard/local/local_settings.py
@@ -36,7 +36,7 @@ WEBROOT = '/'
 # with the list of host/domain names that the application can serve.
 # For more information see:
 # https://docs.djangoproject.com/en/dev/ref/settings/#allowed-hosts
-#ALLOWED_HOSTS = ['horizon.example.com', ]
+ALLOWED_HOSTS = ['10.20.20.1', 'localhost']
 
 # Set SSL proxy settings:
 # Pass this header from the proxy after terminating the SSL,

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -9,19 +9,19 @@ sudo sysctl net.ipv4.ip_forward=1
 echo "Creating OpenStack Databases"
 
 # Wait for MySQL to startup
-while ! nc -z localhost 3306; do sleep 0.1; done;
+while ! nc -z 10.20.20.1 3306; do sleep 0.1; done;
 sleep 5
 
 # Wait for rabbitmq to start
-while ! nc -z localhost 5672; do sleep 0.1; done;
+while ! nc -z 10.20.20.1 5672; do sleep 0.1; done;
 
 for db in neutron nova nova_api nova_cell0 cinder glance keystone; do
-    echo "CREATE DATABASE IF NOT EXISTS ${db}; GRANT ALL PRIVILEGES ON ${db}.* TO '${db}'@'localhost' IDENTIFIED BY '${db}';" \
+    echo "CREATE DATABASE IF NOT EXISTS ${db}; GRANT ALL PRIVILEGES ON ${db}.* TO '${db}'@'10.20.20.1' IDENTIFIED BY '${db}';" \
         | mysql-start-client -u root
 done
 
 # Grant nova user access to cell0
-echo "GRANT ALL PRIVILEGES ON nova_cell0.* TO 'nova'@'localhost' IDENTIFIED BY 'nova';" | mysql-start-client -u root
+echo "GRANT ALL PRIVILEGES ON nova_cell0.* TO 'nova'@'10.20.20.1' IDENTIFIED BY 'nova';" | mysql-start-client -u root
 
 # RabbitMQ
 echo "Configuring RabbitMQ"
@@ -37,12 +37,12 @@ HOME=$SNAP_COMMON/lib/rabbitmq rabbitmqctl set_permissions openstack ".*" ".*" "
 
 # Glance
 echo "Waiting for glance to start."
-while ! nc -z localhost 9292; do sleep 0.1; done;
+while ! nc -z 10.20.20.1 9292; do sleep 0.1; done;
 
 sleep 5
 
 # Wait for identity service
-while ! nc -z localhost 5000; do sleep 0.1; done;
+while ! nc -z 10.20.20.1 5000; do sleep 0.1; done;
 
 openstack image show cirros || {
     [ -f $HOME/images/cirros-0.3.5-x86_64-disk.img ] || {
@@ -56,4 +56,4 @@ openstack image show cirros || {
 }
 
 # Wait for horizon
-while ! nc -z localhost 80; do sleep 0.1; done;
+while ! nc -z 10.20.20.1 80; do sleep 0.1; done;

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -17,7 +17,7 @@ environment:
   OS_PROJECT_NAME: admin
   OS_USERNAME: admin
   OS_PASSWORD: keystone
-  OS_AUTH_URL: http://localhost:5000
+  OS_AUTH_URL: http://10.20.20.1:5000
   OS_IDENTITY_API_VERSION: 3
   OS_IMAGE_API_VERSION: 2
 
@@ -612,8 +612,8 @@ parts:
       - --target-list=x86_64-softmmu
     override-build: |
       wget http://archive.ubuntu.com/ubuntu/pool/main/q/qemu/qemu_2.5+dfsg.orig.tar.xz
-      wget http://archive.ubuntu.com/ubuntu/pool/main/q/qemu/qemu_2.5+dfsg-5ubuntu10.33.debian.tar.xz
-      wget http://archive.ubuntu.com/ubuntu/pool/main/q/qemu/qemu_2.5+dfsg-5ubuntu10.33.dsc
+      wget http://archive.ubuntu.com/ubuntu/pool/main/q/qemu/qemu_2.5+dfsg-5ubuntu10.36.debian.tar.xz
+      wget http://archive.ubuntu.com/ubuntu/pool/main/q/qemu/qemu_2.5+dfsg-5ubuntu10.36.dsc
       dpkg-source -x qemu_*.dsc
       snapcraftctl build
     organize:

--- a/src/experiments/bin/configure-the-things.sh
+++ b/src/experiments/bin/configure-the-things.sh
@@ -6,4 +6,4 @@ set -ex
 
 exit 0
 
-microstack.mysql-client -u root -p$(`sudo cat /var/snap/microstack/common/log/error.log | grep "temporary password" | cut -d " " -f11`) --connect-expired-password | echo "ALTER USER 'root'@'localhost' IDENTIFIED BY 'fnord';"
+microstack.mysql-client -u root -p$(`sudo cat /var/snap/microstack/common/log/error.log | grep "temporary password" | cut -d " " -f11`) --connect-expired-password | echo "ALTER USER 'root'@'10.20.20.1' IDENTIFIED BY 'fnord';"

--- a/src/launch/launch.sh
+++ b/src/launch/launch.sh
@@ -64,4 +64,4 @@ while :; do
     fi
 done
 
-echo "You can also visit the openstack dashboard at 'http://localhost/'"
+echo "You can also visit the openstack dashboard at 'http://10.20.20.1/'"

--- a/tests/configure-the-things.sh
+++ b/tests/configure-the-things.sh
@@ -14,9 +14,9 @@ set -ex
 MYSQL_PASSWORD=fnord  # TODO use snapctl
 MYSQL_TMP_PASSWORD=`sudo cat /var/snap/microstack/common/log/error.log | grep "temporary password" | cut -d " " -f11`
 
-echo "ALTER USER 'root'@'localhost' IDENTIFIED BY 'fnord';" | microstack.mysql-client -u root -p"$MYSQL_TMP_PASSWORD" --connect-expired-password
+echo "ALTER USER 'root'@'10.20.20.1' IDENTIFIED BY 'fnord';" | microstack.mysql-client -u root -p"$MYSQL_TMP_PASSWORD" --connect-expired-password
 
-echo "CREATE DATABASE IF NOT EXISTS keystone; GRANT ALL PRIVILEGES ON keystone.* TO 'keystone'@'localhost' IDENTIFIED BY 'keystone';" | sudo microstack.mysql-client -u root -p"$MYSQL_PASSWORD"
+echo "CREATE DATABASE IF NOT EXISTS keystone; GRANT ALL PRIVILEGES ON keystone.* TO 'keystone'@'10.20.20.1' IDENTIFIED BY 'keystone';" | sudo microstack.mysql-client -u root -p"$MYSQL_PASSWORD"
 
 sudo microstack.keystone-manage fernet_setup --keystone-user root --keystone-group root
 sudo microstack.keystone-manage db_sync
@@ -26,9 +26,9 @@ sudo systemctl restart snap.microstack.*
 microstack.openstack user show admin || {
     sudo microstack.keystone-manage bootstrap \
         --bootstrap-password $OS_PASSWORD \
-        --bootstrap-admin-url http://localhost:5000/v3/ \
-        --bootstrap-internal-url http://localhost:5000/v3/ \
-        --bootstrap-public-url http://localhost:5000/v3/ \
+        --bootstrap-admin-url http://10.20.20.1:5000/v3/ \
+        --bootstrap-internal-url http://10.20.20.1:5000/v3/ \
+        --bootstrap-public-url http://10.20.20.1:5000/v3/ \
         --bootstrap-region-id microstack
 }
 


### PR DESCRIPTION
Updated microstack api endpoints from localhost to 10.20.20.1

Addresses the issue where services such as a juju controller cannot
access endpoints from within an instance.

Updated all references to localhost to 10.20.20.1, and added the
address to ALLOWED_HOSTS.

Also updated version of qemu lib.