### PR TITLE
Fixed test cleanup.

### DIFF
--- a/tests/basic-test.sh
+++ b/tests/basic-test.sh
@@ -66,6 +66,7 @@ done;
 unset IP
 echo "Completed tests. Tearing down $MACHINE."
 multipass stop $MACHINE
+multipass delete $MACHINE
 multipass purge  # This is a little bit rude to do, but we assume that
                  # we can beat up on the test machine a bit.
 


### PR DESCRIPTION
We weren't tearing down multipass properly before, and that could clutter the test runner (e.g. petevg's laptop) with old vms.