### PR TITLE
Moved cirros image into $SNAP_COMMON/images

### DIFF
--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -50,15 +50,17 @@ sleep 5
 # Wait for identity service
 while ! nc -z 10.20.20.1 5000; do sleep 0.1; done;
 
+# Make an in-snap place to store images, and download cirros image
+mkdir -p $SNAP_COMMON/images
 openstack image show cirros || {
-    [ -f $HOME/images/cirros-0.3.5-x86_64-disk.img ] || {
-        mkdir -p $HOME/images
+    [ -f $SNAP_COMMON/images/cirros-0.4.0-x86_64-disk.img ] || {
         wget \
-          http://download.cirros-cloud.net/0.3.5/cirros-0.3.5-x86_64-disk.img \
-          -O ${HOME}/images/cirros-0.3.5-x86_64-disk.img
+          http://download.cirros-cloud.net/0.4.0/cirros-0.4.0-x86_64-disk.img \
+          -O ${SNAP_COMMON}/images/cirros-0.4.0-x86_64-disk.img
     }
-    openstack image create --file ${HOME}/images/cirros-0.3.5-x86_64-disk.img \
-        --public --container-format=bare --disk-format=qcow2 cirros
+    openstack image create \
+              --file ${SNAP_COMMON}/images/cirros-0.4.0-x86_64-disk.img \
+              --public --container-format=bare --disk-format=qcow2 cirros
 }
 
 # Wait for horizon


### PR DESCRIPTION
Previously, we were dropping the image into /images. This is not a
great place to put it, as it gets left behind after the snap is
uninstalled, and is generally hidden from the user.

Putting it in $SNAP_COMMON/images makes it easier to find, and means
that it will get cleaned up when the snap is uninstalled.