### PR TITLE
Moved cirros image into the snap.

### DIFF
--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -50,16 +50,12 @@ sleep 5
 # Wait for identity service
 while ! nc -z 10.20.20.1 5000; do sleep 0.1; done;
 
-openstack image show cirros || {
-    [ -f $HOME/images/cirros-0.3.5-x86_64-disk.img ] || {
-        mkdir -p $HOME/images
-        wget \
-          http://download.cirros-cloud.net/0.3.5/cirros-0.3.5-x86_64-disk.img \
-          -O ${HOME}/images/cirros-0.3.5-x86_64-disk.img
-    }
-    openstack image create --file ${HOME}/images/cirros-0.3.5-x86_64-disk.img \
-        --public --container-format=bare --disk-format=qcow2 cirros
-}
+# Setup the cirros image, which is used by the launch app
+# Clean up a previous version of the image if one exists, as we might
+# be upgrading.
+openstack image show cirros && openstack image delete cirros
+openstack image create --file ${SNAP}/data/cirros-0.4.0-x86_64-disk.img \
+          --public --container-format=bare --disk-format=qcow2 cirros
 
 # Wait for horizon
 while ! nc -z 10.20.20.1 80; do sleep 0.1; done;


### PR DESCRIPTION
Put it in the data dir, along with the mysql tarball. It's therefore
available to the configure script, in a predictable place.

The process to update the cirros image is to

1) Update the image in data
2) Update the configure script to point to the new image.