### PR TITLE
Moved cirros image to /var/snap/microstack/common/images

### DIFF
--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -50,14 +50,16 @@ sleep 5
 # Wait for identity service
 while ! nc -z 10.20.20.1 5000; do sleep 0.1; done;
 
+# Setup the cirros image, which is used by the launch app
 openstack image show cirros || {
-    [ -f $HOME/images/cirros-0.3.5-x86_64-disk.img ] || {
-        mkdir -p $HOME/images
+    [ -f $SNAP_COMMON/images/cirros-0.4.0-x86_64-disk.img ] || {
+        mkdir -p $SNAP_COMMON/images
         wget \
-          http://download.cirros-cloud.net/0.3.5/cirros-0.3.5-x86_64-disk.img \
-          -O ${HOME}/images/cirros-0.3.5-x86_64-disk.img
+          http://download.cirros-cloud.net/0.4.0/cirros-0.4.0-x86_64-disk.img \
+          -O ${SNAP_COMMON}/images/cirros-0.4.0-x86_64-disk.img
     }
-    openstack image create --file ${HOME}/images/cirros-0.3.5-x86_64-disk.img \
+    openstack image create \
+        --file ${SNAP_COMMON}/images/cirros-0.4.0-x86_64-disk.img \
         --public --container-format=bare --disk-format=qcow2 cirros
 }
 


### PR DESCRIPTION
This way, it will get cleaned up when we uninstall the snap.

Also added test hooks to test upgrades, to verify that we aren't
breaking existing snaps.