### PR TITLE
Refactored snap to work with core18.

### DIFF
--- a/snap-overlay/bin/configure-openstack
+++ b/snap-overlay/bin/configure-openstack
@@ -1,172 +1,88 @@
-#!/bin/bash -e
+#!/bin/sh
 
-# Keystone
-echo "Configuring Keystone"
+# Install
 
+set -ex
+
+# Configure Keystone Fernet Keys
 snap-openstack keystone-manage fernet_setup --keystone-user root --keystone-group root
-snap-openstack keystone-manage db_sync
+keystone-manage db_sync
 
-systemctl restart snap.microstack.keystone-*
+systemctl restart snap.microstack.keystone*
 
 openstack user show admin || {
-    snap-openstack keystone-manage bootstrap \
-        --bootstrap-password $OS_PASSWORD \
-        --bootstrap-admin-url http://10.20.20.1:5000/v3/ \
-        --bootstrap-internal-url http://10.20.20.1:5000/v3/ \
-        --bootstrap-public-url http://10.20.20.1:5000/v3/ \
+    keystone-manage bootstrap \
+        --bootstrap-password keystone \
+        --bootstrap-admin-url http://localhost:35357/v3/ \
+        --bootstrap-internal-url http://localhost:35357/v3/ \
+        --bootstrap-public-url http://localhost:5000/v3/ \
         --bootstrap-region-id microstack
 }
 
-openstack project show service || {
-    openstack project create --domain default --description "Service Project" service
-}
+# Open up networking so that instances can route to the Internet (see
+# bin/setup-br-ex for more networking setup, executed on microstack
+# services start.)
+sudo sysctl net.ipv4.ip_forward=1
 
-# Nova
-echo "Configuring Nova"
+# Create all of the databases
+echo "Creating OpenStack Databases"
 
-openstack user show nova || {
-    openstack user create --domain default --password nova nova
-    openstack role add --project service --user nova admin
-}
-
-openstack user show placement || {
-    openstack user create --domain default --password placement placement
-    openstack role add --project service --user placement admin
-}
-
-openstack service show compute || {
-    openstack service create --name nova \
-      --description "OpenStack Compute" compute
-
-    for endpoint in public internal admin; do
-        openstack endpoint create --region microstack \
-          compute $endpoint http://10.20.20.1:8774/v2.1 || :
-    done
-}
-
-openstack service show placement || {
-    openstack service create --name placement \
-      --description "Placement API" placement
-
-    for endpoint in public internal admin; do
-        openstack endpoint create --region microstack \
-          placement $endpoint http://10.20.20.1:8778 || :
-    done
-}
-
-snap-openstack nova-manage api_db sync
-snap-openstack nova-manage cell_v2 list_cells | grep cell0 || {
-    snap-openstack nova-manage cell_v2 map_cell0
-}
-snap-openstack nova-manage cell_v2 list_cells | grep cell1 || {
-    snap-openstack nova-manage cell_v2 create_cell --name=cell1 --verbose
-}
-snap-openstack nova-manage db sync
-
-systemctl restart snap.microstack.nova-*
-
-while ! nc -z 10.20.20.1 8774; do sleep 0.1; done;
-
+# Wait for MySQL to startup
+while ! nc -z 10.20.20.1 3306; do sleep 0.1; done;
 sleep 5
 
-openstack flavor show m1.tiny || {
-    openstack flavor create --id 1 --ram 512 --disk 1 --vcpus 1 m1.tiny
-}
-openstack flavor show m1.small || {
-    openstack flavor create --id 2 --ram 2048 --disk 20 --vcpus 1 m1.small
-}
-openstack flavor show m1.medium || {
-    openstack flavor create --id 3 --ram 4096 --disk 20 --vcpus 2 m1.medium
-}
-openstack flavor show m1.large || {
-    openstack flavor create --id 4 --ram 8192 --disk 20 --vcpus 4 m1.large
-}
-openstack flavor show m1.xlarge || {
-    openstack flavor create --id 5 --ram 16384 --disk 20 --vcpus 8 m1.xlarge
-}
+# Wait for rabbitmq to start
+while ! nc -z 10.20.20.1 5672; do sleep 0.1; done;
 
-# Neutron
-echo "Configuring Neutron"
+for db in neutron nova nova_api nova_cell0 cinder glance keystone; do
+    echo "CREATE DATABASE IF NOT EXISTS ${db}; GRANT ALL PRIVILEGES ON ${db}.* TO '${db}'@'10.20.20.1' IDENTIFIED BY '${db}';" \
+        | mysql-start-client -u root
+done
 
-openstack user show neutron || {
-    openstack user create --domain default --password neutron neutron
-    openstack role add --project service --user neutron admin
-}
+# Grant nova user access to cell0
+echo "GRANT ALL PRIVILEGES ON nova_cell0.* TO 'nova'@'10.20.20.1' IDENTIFIED BY 'nova';" | mysql-start-client -u root
 
-openstack service show network || {
-    openstack service create --name neutron \
-      --description "OpenStack Network" network
+# Endpoints from localhost -> 10.20.20.1
+# TODO Rebuild database so that these are already set to 10.20.20.1,
+# after lp:1824176 is addressed, and the process of building a new
+# mysql.tar.xz is less fraught.
+openstack endpoint list | grep localhost | while read line; do openstack endpoint set `echo $line | cut -d" " -f2` --url `echo $line | cut -d" " -f14 | sed 's/localhost/10.20.20.1/'`; done
 
-    for endpoint in public internal admin; do
-        openstack endpoint create --region microstack \
-          network $endpoint http://10.20.20.1:9696 || :
-    done
-}
+# RabbitMQ
+echo "Configuring RabbitMQ"
+# Rabbitmq isn't always started when we run this. Wait for it to start.
+while :;
+do
+    grep "Starting broker..." ${SNAP_COMMON}/log/rabbitmq/startup_log && \
+        grep "completed" ${SNAP_COMMON}/log/rabbitmq/startup_log && \
+        break
+    echo "waiting for rabbitmq to start" && sleep 1;
+done
 
-snap-openstack neutron-db-manage upgrade head
-
-systemctl restart snap.microstack.neutron-*
-
-while ! nc -z 10.20.20.1 9696; do sleep 0.1; done;
-
-sleep 5
-
-openstack network show test || {
-    openstack network create test
-}
-
-openstack subnet show test-subnet || {
-    openstack subnet create --network test --subnet-range 192.168.222.0/24 test-subnet
-}
-
-openstack network show external || {
-    openstack network create --external \
-        --provider-physical-network=physnet1 \
-        --provider-network-type=flat external
-}
-
-openstack subnet show external-subnet || {
-    openstack subnet create --network external --subnet-range 10.20.20.0/24 \
-        --no-dhcp external-subnet
-}
-
-openstack router show test-router || {
-    openstack router create test-router
-    openstack router add subnet test-router test-subnet
-    openstack router set --external-gateway external test-router
-}
+HOME=$SNAP_COMMON/lib/rabbitmq rabbitmqctl add_user openstack rabbitmq || :
+HOME=$SNAP_COMMON/lib/rabbitmq rabbitmqctl set_permissions openstack ".*" ".*" ".*"
 
 # Glance
-echo "Configuring Glance"
-
-openstack user show glance || {
-    openstack user create --domain default --password glance glance
-    openstack role add --project service --user glance admin
-}
-
-openstack service show image || {
-    openstack service create --name glance --description "OpenStack Image" image
-    for endpoint in internal admin public; do
-        openstack endpoint create --region microstack \
-            image $endpoint http://10.20.20.1:9292 || :
-    done
-}
-
-snap-openstack glance-manage db_sync
-
-systemctl restart snap.microstack.glance*
-
+echo "Waiting for glance to start."
 while ! nc -z 10.20.20.1 9292; do sleep 0.1; done;
 
 sleep 5
 
+# Wait for identity service
+while ! nc -z 10.20.20.1 5000; do sleep 0.1; done;
+
+# Setup the cirros image, which is used by the launch app
 openstack image show cirros || {
-    [ -f $HOME/images/cirros-0.3.5-x86_64-disk.img ] || {
-        mkdir -p $HOME/images
-        wget \
-          http://download.cirros-cloud.net/0.3.5/cirros-0.3.5-x86_64-disk.img \
-          -O ${HOME}/images/cirros-0.3.5-x86_64-disk.img
+    [ -f $SNAP_COMMON/images/cirros-0.4.0-x86_64-disk.img ] || {
+        mkdir -p $SNAP_COMMON/images
+        curl \
+          http://download.cirros-cloud.net/0.4.0/cirros-0.4.0-x86_64-disk.img \
+          --output ${SNAP_COMMON}/images/cirros-0.4.0-x86_64-disk.img
     }
-    openstack image create --file ${HOME}/images/cirros-0.3.5-x86_64-disk.img \
+    openstack image create \
+        --file ${SNAP_COMMON}/images/cirros-0.4.0-x86_64-disk.img \
         --public --container-format=bare --disk-format=qcow2 cirros
 }
+
+# Wait for horizon
+while ! nc -z 10.20.20.1 80; do sleep 0.1; done;

--- a/snap-overlay/libvirt/libvirtd.conf
+++ b/snap-overlay/libvirt/libvirtd.conf
@@ -1,0 +1,1 @@
+# Snap provided configuration

--- a/snap-wrappers/rabbitmq/erl
+++ b/snap-wrappers/rabbitmq/erl
@@ -19,7 +19,7 @@
 # %CopyrightEnd%
 #
 ROOTDIR=$SNAP/usr/lib/erlang
-BINDIR=$ROOTDIR/erts-7.3/bin
+BINDIR=$ROOTDIR/erts-9.2/bin
 EMU=beam
 PROGNAME=`echo $0 | sed 's/.*\///'`
 export EMU

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -34,7 +34,9 @@ echo "Configuring RabbitMQ"
 # Rabbitmq isn't always started when we run this. Wait for it to start.
 while :;
 do
-    grep "Starting broker... completed" ${SNAP_COMMON}/log/rabbitmq/startup_log && break
+    grep "Starting broker..." ${SNAP_COMMON}/log/rabbitmq/startup_log && \
+        grep "completed" ${SNAP_COMMON}/log/rabbitmq/startup_log && \
+        break
     echo "waiting for rabbitmq to start" && sleep 1;
 done
 
@@ -65,3 +67,9 @@ openstack image show cirros || {
 
 # Wait for horizon
 while ! nc -z 10.20.20.1 80; do sleep 0.1; done;
+
+# Restart Placement API
+# Workaround for issue w/ base:core18, where the Placement API throws
+# http 500s until it has been restarted.
+# TODO: root cause and fix the problem.
+systemctl restart snap.microstack.nova-uwsgi.service

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -1,9 +1,7 @@
 #!/bin/sh
 set -e
 
-install -D $SNAP/var/snap/microstack/common/libvirt/libvirtd.conf $SNAP_COMMON/libvirt/libvirtd.conf
-sed -i 's/unix_sock_group = "libvirtd"/unix_sock_group = "sudo"/' $SNAP_COMMON/libvirt/libvirtd.conf
-
+# No config branch -- don't run this!
 # MySQL snapshot for speedy install
 # snapshot is a mysql data dir with
 # rocky keystone,nova,glance,neutron dbs.
@@ -17,5 +15,6 @@ for project in neutron nova keystone glance; do
     cp -r ${SNAP}/etc/${project}/${project}.conf.d/* ${SNAP_COMMON}/etc/${project}/${project}.conf.d
 done
 
+# No config branch -- don't run this!
 # Configure Keystone Fernet Keys
 snap-openstack keystone-manage fernet_setup --keystone-user root --keystone-group root

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,5 +1,6 @@
 name: microstack
 version: rocky
+base: core18
 summary: OpenStack on your laptop.
 description: |
   Microstack gives you an easy way to develop and test OpenStack
@@ -225,12 +226,13 @@ apps:
 
   # Libvirt/Qemu
   libvirtd:
-    command: libvirtd
+    command: sbin/libvirtd
     daemon: simple
-    environment:
-      LD_LIBRARY_PATH: $SNAP/lib:$SNAP/lib/$SNAPCRAFT_ARCH_TRIPLET:$SNAP/usr/lib:$SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET:$SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/pulseaudio
+  virtlogd:
+    command: sbin/virtlogd
+    daemon: simple    
   virsh:
-    command: virsh
+    command: bin/virsh
 
   # MySQL
   mysqld:
@@ -315,7 +317,8 @@ parts:
   openstack-projects:
     plugin: python
     python-version: python2
-    constraints: https://raw.githubusercontent.com/openstack/requirements/stable/rocky/upper-constraints.txt
+    constraints:
+      - https://raw.githubusercontent.com/openstack/requirements/stable/rocky/upper-constraints.txt
     source: http://tarballs.openstack.org/keystone/keystone-stable-rocky.tar.gz
     python-packages:
       - libvirt-python
@@ -338,10 +341,12 @@ parts:
       - libxml2-dev
       - libxslt1-dev
       - libvirt-dev
+      - git
     stage-packages:
       - conntrack
       - coreutils
       - haproxy
+      - libpython2.7
     override-build: |
       # Ensure libvirt is discovered from previous built part
       export PKG_CONFIG_PATH=$SNAPCRAFT_STAGE/lib/pkgconfig
@@ -528,94 +533,54 @@ parts:
 
   # libvirt/qemu
   qemu:
-    source: .
-    source-subdir: qemu-2.5+dfsg
+    source: http://wiki.qemu-project.org/download/qemu-2.12.1.tar.bz2
     plugin: autotools
-    stage-packages:
-      - seabios
-      - ipxe-qemu
-      - try:
-        - libnuma1
-        - libspice-server1
-      - libasound2
-      - libasyncns0
-      - libbluetooth3
-      - libboost-iostreams1.58.0
-      - libboost-random1.58.0
-      - libboost-system1.58.0
-      - libboost-thread1.58.0
-      - libcaca0
-      - libfdt1
-      - libflac8
-      - libiscsi2
-      - libjpeg-turbo8
-      - libnspr4
-      - libnss3
-      - libogg0
-      - libopus0
-      - libpixman-1-0
-      - libpulse0
-      - librados2
-      - librbd1
-      - libsdl1.2debian
-      - libsndfile1
-      - libusb-1.0-0
-      - libusbredirparser1
-      - libvorbis0a
-      - libvorbisenc2
-      - libx11-6
-      - libxau6
-      - libxcb1
-      - libxdmcp6
-      - libxext6
     build-packages:
-      - acpica-tools
       - libaio-dev
+      - acpica-tools
       - libasound2-dev
       - libattr1-dev
-      - libbluetooth-dev
       - libcap-dev
       - libcap-ng-dev
-      - libcurl4-gnutls-dev
-      - libfdt-dev
-      - gnutls-dev
       - libiscsi-dev
-      - libncurses5-dev
-      - try: [libnuma-dev]
-      - libpixman-1-dev
-      - libpulse-dev
+      - libnuma-dev
       - librados-dev
       - librbd-dev
-      - libsasl2-dev
-      - libsdl1.2-dev
-      - try: [libspice-server-dev, libspice-protocol-dev]
+      - libpixman-1-dev
+      - libspice-server-dev
+      - libspice-protocol-dev
       - libusb-1.0-0-dev
       - libusbredirparser-dev
-      - linux-libc-dev
-      - uuid-dev
-      - xfslibs-dev
-      - libjpeg-dev
       - zlib1g-dev
-      - libpng-dev
-      - wget
-      - dpkg-dev
-      - gcc
+      - uuid-dev
+    stage-packages:
+      - libxml2
+      - libyajl2
+      - libnuma1
+      - libaio1
+      - libiscsi7
+      - libcurl3-gnutls
+      - librbd1
+      - librados2
+      - libcairo2
+      - libgdk-pixbuf2.0-0
+      - libpixman-1-0
+      - libgtk2.0-0
+      - libspice-server1
+      - libusb-1.0-0
+      - libusbredirparser1
+      - libxen-dev
+      - libx11-6
     configflags:
-      - --disable-blobs
-      - --prefix=/snap/$SNAPCRAFT_PROJECT_NAME/current
-      - --localstatedir=/var/snap/$SNAPCRAFT_PROJECT_NAME/common
-      - --sysconfdir=/var/snap/$SNAPCRAFT_PROJECT_NAME/common
-      - --extra-cflags=-DCONFIG_QEMU_DATAPATH='"/snap/$SNAPCRAFT_PROJECT_NAME/current/share/qemu:/snap/$SNAPCRAFT_PROJECT_NAME/current/usr/share/seabios:/snap/$SNAPCRAFT_PROJECT_NAME/current/usr/lib/ipxe/qemu"'
-      - --disable-user
-      - --disable-linux-user
-      - --enable-system
-      - --target-list=x86_64-softmmu
-    override-build: |
-      wget http://archive.ubuntu.com/ubuntu/pool/main/q/qemu/qemu_2.5+dfsg.orig.tar.xz
-      wget http://archive.ubuntu.com/ubuntu/pool/main/q/qemu/qemu_2.5+dfsg-5ubuntu10.36.debian.tar.xz
-      wget http://archive.ubuntu.com/ubuntu/pool/main/q/qemu/qemu_2.5+dfsg-5ubuntu10.36.dsc
-      dpkg-source -x qemu_*.dsc
-      snapcraftctl build
+        - --target-list=x86_64-softmmu i386-softmmu
+        - --prefix=/snap/$SNAPCRAFT_PROJECT_NAME/current
+        - --localstatedir=/var/snap/$SNAPCRAFT_PROJECT_NAME/common
+        - --sysconfdir=/var/snap/$SNAPCRAFT_PROJECT_NAME/common
+        - --extra-cflags=-DCONFIG_QEMU_DATAPATH='"/snap/$SNAPCRAFT_PROJECT_NAME/curent/share/qemu:/snap/$SNAPCRAFT_PROJECT_NAME/current/usr/share/seabios:/snap/$SNAPCRAFT_PROJECT_NAME/current/usr/lib/ipxe/qemu"'
+        - --disable-user
+        - --disable-linux-user
+        - --enable-system
+
     organize:
       # Hack to shift installed qemu back to root of snap
       # required to ensure that pathing to files etc works at
@@ -623,84 +588,77 @@ parts:
       # * is not used to avoid directory merge conflicts
       snap/microstack/current/: ./
 
-  kvm-support:
-    plugin: nil
-    stage-packages:
-    - try: [msr-tools]
-
   libvirt:
-    source: .
-    source-subdir: libvirt-1.3.1
+    source: https://libvirt.org/sources/libvirt-3.10.0.tar.xz
     plugin: autotools
     build-packages:
-    - libxml2-dev
-    - libxml-libxml-perl
-    - libcurl4-gnutls-dev
-    - libncurses5-dev
-    - libreadline-dev
-    - zlib1g-dev
-    - libgcrypt20-dev
-    - libgnutls28-dev
-    - libyajl-dev
-    - libpcap0.8-dev
-    - libaudit-dev
-    - libdevmapper-dev
-    - libpciaccess-dev
-    - libnl-3-dev
-    - libnl-route-3-dev
-    - uuid-dev
-    - try: [libnuma-dev]
-    - wget
-    - dpkg-dev
+      - libxml2-dev
+      - libcurl4-gnutls-dev
+      - libncurses5-dev
+      - libreadline-dev
+      - zlib1g-dev
+      - libgcrypt20-dev
+      - libgnutls28-dev
+      - libsasl2-dev
+      - libsanlock-dev
+      - libiscsi-dev
+      - librbd-dev
+      - librados-dev
+      - libyajl-dev
+      - libpcap0.8-dev
+      - libaudit-dev
+      - libdevmapper-dev
+      - libpciaccess-dev
+      - libnl-3-dev
+      - libnl-route-3-dev
+      - libpolkit-gobject-1-dev
+      - libxml2-utils
+      - uuid-dev
+      - libnuma-dev
+      - python-all
+      - python-six
+      - xsltproc
     stage-packages:
-    - try: [dmidecode]
-    - dnsmasq
-    - dnsmasq-utils
-    - ebtables
-    - libxml2
-    - libyajl2
-    - try: [libnuma1]
-    - libcurl3-gnutls
-    - libpciaccess0
+      - libxml2
+      - libyajl2
+      - libnuma1
+      - libcurl3-gnutls
     configflags:
-    - --with-qemu
-    - --without-bhyve
-    - --without-xen
-    - --without-openvz
-    - --without-vmware
-    - --without-xenapi
-    - --without-esx
-    - --without-hyperv
-    - --without-lxc
-    - --without-vz
-    - --without-vbox
-    - --without-uml
-    - --without-sasl
-    - --without-storage-iscsi
-    - --without-storage-sheepdog
-    - --without-storage-rbd
-    - --without-storage-lvm
-    - --without-selinux
-    - --prefix=/snap/$SNAPCRAFT_PROJECT_NAME/current
-    - --localstatedir=/var/snap/$SNAPCRAFT_PROJECT_NAME/common
-    - --sysconfdir=/var/snap/$SNAPCRAFT_PROJECT_NAME/common
-    - DNSMASQ=/snap/$SNAPCRAFT_PROJECT_NAME/current/usr/sbin/dnsmasq
-    - DMIDECODE=/snap/$SNAPCRAFT_PROJECT_NAME/current/usr/sbin/dmidecode
-    - OVSVSCTL=/snap/$SNAPCRAFT_PROJECT_NAME/current/bin/ovs-vsctl
-    - EBTABLES_PATH=/snap/$SNAPCRAFT_PROJECT_NAME/current/sbin/ebtables
-    - IPTABLES_PATH=/snap/$SNAPCRAFT_PROJECT_NAME/current/sbin/iptables
-    override-build: |
-      wget http://archive.ubuntu.com/ubuntu/pool/main/libv/libvirt/libvirt_1.3.1.orig.tar.gz
-      wget http://archive.ubuntu.com/ubuntu/pool/main/libv/libvirt/libvirt_1.3.1-1ubuntu10.25.debian.tar.xz
-      wget http://archive.ubuntu.com/ubuntu/pool/main/libv/libvirt/libvirt_1.3.1-1ubuntu10.25.dsc
-      dpkg-source -x libvirt*.dsc
-      snapcraftctl build
+        - --with-qemu
+        - --without-xen
+        - --without-openvz
+        - --without-vmware
+        - --without-xenapi
+        - --without-esx
+        - --without-hyperv
+        - --without-lxc
+        - --without-vz
+        - --without-vbox
+        - --without-uml
+        - --without-sasl
+        - --prefix=/snap/$SNAPCRAFT_PROJECT_NAME/current
+        - --localstatedir=/var/snap/$SNAPCRAFT_PROJECT_NAME/common
+        - --sysconfdir=/var/snap/$SNAPCRAFT_PROJECT_NAME/common
+        - DNSMASQ=/snap/$SNAPCRAFT_PROJECT_NAME/current/usr/sbin/dnsmasq
+        - DMIDECODE=/snap/$SNAPCRAFT_PROJECT_NAME/current/usr/sbin/dmidecode
+        - OVSVSCTL=/snap/$SNAPCRAFT_PROJECT_NAME/current/bin/ovs-vsctl
+        - EBTABLES_PATH=/snap/$SNAPCRAFT_PROJECT_NAME/current/sbin/ebtables
     organize:
       # Hack to shift installed libvirt back to root of snap
       # required to ensure that pathing to files etc works at
       # runtime
       # * is not used to avoid directory merge conflicts
       snap/microstack/current/: ./
+    filesets:
+      all:
+        - -etc/libvirt/libvirtd.conf
+    stage: [$all]
+    prime: [$all]
+
+  kvm-support:
+    plugin: nil
+    stage-packages:
+    - try: [msr-tools]
 
   # MySQL
   mysql-server:
@@ -733,13 +691,13 @@ parts:
   # Memcached Token Caching
   memcached:
     plugin: autotools
-    source: https://memcached.org/files/memcached-1.5.10.tar.gz
+    source: https://memcached.org/files/memcached-1.5.14.tar.gz
     build-packages:
       - libevent-dev
       - gcc
       - make
     stage-packages:
-      - libevent-2.0-5
+      - libevent-2.1-6
     override-build: |
       ./configure --prefix=$SNAPCRAFT_PART_INSTALL
       make
@@ -759,7 +717,7 @@ parts:
     source: https://www.kernel.org/pub/linux/utils/net/bridge-utils/bridge-utils-1.6.tar.gz
     plugin: autotools
   iproute2:
-    source: https://www.kernel.org/pub/linux/utils/net/iproute2/iproute2-4.9.0.tar.gz
+    source: https://www.kernel.org/pub/linux/utils/net/iproute2/iproute2-4.20.0.tar.gz
     plugin: autotools
     build-packages:
       - bison
@@ -773,7 +731,8 @@ parts:
     configflags:
       - --disable-nftables
       - --prefix=/snap/$SNAPCRAFT_PROJECT_NAME/current
-    install: |
+    override-build: |
+      snapcraftctl build
       cp --remove-destination $SNAPCRAFT_PART_INSTALL/snap/$SNAPCRAFT_PROJECT_NAME/current/sbin/xtables-multi \
         $SNAPCRAFT_PART_INSTALL/snap/$SNAPCRAFT_PROJECT_NAME/current/bin/iptables-xml
     organize:
@@ -800,6 +759,9 @@ parts:
 
   # Openstack Shared Parts
   overlay:
+    after:
+      - libvirt
+      - qemu
     plugin: dump
     source: snap-overlay
 

--- a/tests/basic-test.sh
+++ b/tests/basic-test.sh
@@ -42,6 +42,9 @@ fi
 multipass exec $MACHINE -- \
           sudo snap install --classic --dangerous microstack*.snap
 
+# Run configure script!
+#multipass exec $MACHINE -- sudo microstack.configure
+
 # Run microstack.launch
 multipass exec $MACHINE -- /snap/bin/microstack.launch breakfast
 


### PR DESCRIPTION
Giving the snapcraft.yaml a base property helps tremendously with the
efficiency of the build process, and I believe that it puts us in a
better position to reliably support non Ubuntu distros going forward.

This also bases us on long supported bionic libraries, and gives us a
nice place to work from as we add Python 3 and Stein support, as well
as general polish and fixes.