### PR TITLE
Fix snapcraft build after qemu_2.5 source package rebuilding

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -612,8 +612,8 @@ parts:
       - --target-list=x86_64-softmmu
     override-build: |
       wget http://archive.ubuntu.com/ubuntu/pool/main/q/qemu/qemu_2.5+dfsg.orig.tar.xz
-      wget http://archive.ubuntu.com/ubuntu/pool/main/q/qemu/qemu_2.5+dfsg-5ubuntu10.36.debian.tar.xz
-      wget http://archive.ubuntu.com/ubuntu/pool/main/q/qemu/qemu_2.5+dfsg-5ubuntu10.36.dsc
+      wget http://archive.ubuntu.com/ubuntu/pool/main/q/qemu/qemu_2.5+dfsg-5ubuntu10.38.debian.tar.xz
+      wget http://archive.ubuntu.com/ubuntu/pool/main/q/qemu/qemu_2.5+dfsg-5ubuntu10.38.dsc
       dpkg-source -x qemu_*.dsc
       snapcraftctl build
     organize:


### PR DESCRIPTION
qemu_2.5+dfsg-5ubuntu10.36.debian.tar.xz (404) -> 10.38