### PR TITLE
Refactored snap to work with core18.

### DIFF
--- a/snap-overlay/libvirt/libvirtd.conf
+++ b/snap-overlay/libvirt/libvirtd.conf
@@ -1,0 +1,1 @@
+# Snap provided configuration

--- a/snap-wrappers/rabbitmq/erl
+++ b/snap-wrappers/rabbitmq/erl
@@ -19,7 +19,7 @@
 # %CopyrightEnd%
 #
 ROOTDIR=$SNAP/usr/lib/erlang
-BINDIR=$ROOTDIR/erts-7.3/bin
+BINDIR=$ROOTDIR/erts-9.2/bin
 EMU=beam
 PROGNAME=`echo $0 | sed 's/.*\///'`
 export EMU

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -34,7 +34,9 @@ echo "Configuring RabbitMQ"
 # Rabbitmq isn't always started when we run this. Wait for it to start.
 while :;
 do
-    grep "Starting broker... completed" ${SNAP_COMMON}/log/rabbitmq/startup_log && break
+    grep "Starting broker..." ${SNAP_COMMON}/log/rabbitmq/startup_log && \
+        grep "completed" ${SNAP_COMMON}/log/rabbitmq/startup_log && \
+        break
     echo "waiting for rabbitmq to start" && sleep 1;
 done
 
@@ -65,3 +67,9 @@ openstack image show cirros || {
 
 # Wait for horizon
 while ! nc -z 10.20.20.1 80; do sleep 0.1; done;
+
+# Restart Placement API
+# Workaround for issue w/ base:core18, where the Placement API throws
+# http 500s until it has been restarted.
+# TODO: root cause and fix the problem.
+systemctl restart snap.microstack.nova-uwsgi.service

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -1,9 +1,6 @@
 #!/bin/sh
 set -e
 
-install -D $SNAP/var/snap/microstack/common/libvirt/libvirtd.conf $SNAP_COMMON/libvirt/libvirtd.conf
-sed -i 's/unix_sock_group = "libvirtd"/unix_sock_group = "sudo"/' $SNAP_COMMON/libvirt/libvirtd.conf
-
 # MySQL snapshot for speedy install
 # snapshot is a mysql data dir with
 # rocky keystone,nova,glance,neutron dbs.

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,5 +1,6 @@
 name: microstack
 version: rocky
+base: core18
 summary: OpenStack on your laptop.
 description: |
   Microstack gives you an easy way to develop and test OpenStack
@@ -225,12 +226,13 @@ apps:
 
   # Libvirt/Qemu
   libvirtd:
-    command: libvirtd
+    command: sbin/libvirtd
     daemon: simple
-    environment:
-      LD_LIBRARY_PATH: $SNAP/lib:$SNAP/lib/$SNAPCRAFT_ARCH_TRIPLET:$SNAP/usr/lib:$SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET:$SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/pulseaudio
+  virtlogd:
+    command: sbin/virtlogd
+    daemon: simple
   virsh:
-    command: virsh
+    command: bin/virsh
 
   # MySQL
   mysqld:
@@ -315,7 +317,8 @@ parts:
   openstack-projects:
     plugin: python
     python-version: python2
-    constraints: https://raw.githubusercontent.com/openstack/requirements/stable/rocky/upper-constraints.txt
+    constraints:
+      - https://raw.githubusercontent.com/openstack/requirements/stable/rocky/upper-constraints.txt
     source: http://tarballs.openstack.org/keystone/keystone-stable-rocky.tar.gz
     python-packages:
       - libvirt-python
@@ -338,10 +341,12 @@ parts:
       - libxml2-dev
       - libxslt1-dev
       - libvirt-dev
+      - git
     stage-packages:
       - conntrack
       - coreutils
       - haproxy
+      - libpython2.7
     override-build: |
       # Ensure libvirt is discovered from previous built part
       export PKG_CONFIG_PATH=$SNAPCRAFT_STAGE/lib/pkgconfig
@@ -528,94 +533,54 @@ parts:
 
   # libvirt/qemu
   qemu:
-    source: .
-    source-subdir: qemu-2.5+dfsg
+    source: http://wiki.qemu-project.org/download/qemu-2.12.1.tar.bz2
     plugin: autotools
-    stage-packages:
-      - seabios
-      - ipxe-qemu
-      - try:
-        - libnuma1
-        - libspice-server1
-      - libasound2
-      - libasyncns0
-      - libbluetooth3
-      - libboost-iostreams1.58.0
-      - libboost-random1.58.0
-      - libboost-system1.58.0
-      - libboost-thread1.58.0
-      - libcaca0
-      - libfdt1
-      - libflac8
-      - libiscsi2
-      - libjpeg-turbo8
-      - libnspr4
-      - libnss3
-      - libogg0
-      - libopus0
-      - libpixman-1-0
-      - libpulse0
-      - librados2
-      - librbd1
-      - libsdl1.2debian
-      - libsndfile1
-      - libusb-1.0-0
-      - libusbredirparser1
-      - libvorbis0a
-      - libvorbisenc2
-      - libx11-6
-      - libxau6
-      - libxcb1
-      - libxdmcp6
-      - libxext6
     build-packages:
-      - acpica-tools
       - libaio-dev
+      - acpica-tools
       - libasound2-dev
       - libattr1-dev
-      - libbluetooth-dev
       - libcap-dev
       - libcap-ng-dev
-      - libcurl4-gnutls-dev
-      - libfdt-dev
-      - gnutls-dev
       - libiscsi-dev
-      - libncurses5-dev
-      - try: [libnuma-dev]
-      - libpixman-1-dev
-      - libpulse-dev
+      - libnuma-dev
       - librados-dev
       - librbd-dev
-      - libsasl2-dev
-      - libsdl1.2-dev
-      - try: [libspice-server-dev, libspice-protocol-dev]
+      - libpixman-1-dev
+      - libspice-server-dev
+      - libspice-protocol-dev
       - libusb-1.0-0-dev
       - libusbredirparser-dev
-      - linux-libc-dev
-      - uuid-dev
-      - xfslibs-dev
-      - libjpeg-dev
       - zlib1g-dev
-      - libpng-dev
-      - wget
-      - dpkg-dev
-      - gcc
+      - uuid-dev
+    stage-packages:
+      - libxml2
+      - libyajl2
+      - libnuma1
+      - libaio1
+      - libiscsi7
+      - libcurl3-gnutls
+      - librbd1
+      - librados2
+      - libcairo2
+      - libgdk-pixbuf2.0-0
+      - libpixman-1-0
+      - libgtk2.0-0
+      - libspice-server1
+      - libusb-1.0-0
+      - libusbredirparser1
+      - libxen-dev
+      - libx11-6
     configflags:
-      - --disable-blobs
-      - --prefix=/snap/$SNAPCRAFT_PROJECT_NAME/current
-      - --localstatedir=/var/snap/$SNAPCRAFT_PROJECT_NAME/common
-      - --sysconfdir=/var/snap/$SNAPCRAFT_PROJECT_NAME/common
-      - --extra-cflags=-DCONFIG_QEMU_DATAPATH='"/snap/$SNAPCRAFT_PROJECT_NAME/current/share/qemu:/snap/$SNAPCRAFT_PROJECT_NAME/current/usr/share/seabios:/snap/$SNAPCRAFT_PROJECT_NAME/current/usr/lib/ipxe/qemu"'
-      - --disable-user
-      - --disable-linux-user
-      - --enable-system
-      - --target-list=x86_64-softmmu
-    override-build: |
-      wget http://archive.ubuntu.com/ubuntu/pool/main/q/qemu/qemu_2.5+dfsg.orig.tar.xz
-      wget http://archive.ubuntu.com/ubuntu/pool/main/q/qemu/qemu_2.5+dfsg-5ubuntu10.36.debian.tar.xz
-      wget http://archive.ubuntu.com/ubuntu/pool/main/q/qemu/qemu_2.5+dfsg-5ubuntu10.36.dsc
-      dpkg-source -x qemu_*.dsc
-      snapcraftctl build
+        - --target-list=x86_64-softmmu i386-softmmu
+        - --prefix=/snap/$SNAPCRAFT_PROJECT_NAME/current
+        - --localstatedir=/var/snap/$SNAPCRAFT_PROJECT_NAME/common
+        - --sysconfdir=/var/snap/$SNAPCRAFT_PROJECT_NAME/common
+        - --extra-cflags=-DCONFIG_QEMU_DATAPATH='"/snap/$SNAPCRAFT_PROJECT_NAME/curent/share/qemu:/snap/$SNAPCRAFT_PROJECT_NAME/current/usr/share/seabios:/snap/$SNAPCRAFT_PROJECT_NAME/current/usr/lib/ipxe/qemu"'
+        - --disable-user
+        - --disable-linux-user
+        - --enable-system
+
     organize:
       # Hack to shift installed qemu back to root of snap
       # required to ensure that pathing to files etc works at
@@ -623,84 +588,80 @@ parts:
       # * is not used to avoid directory merge conflicts
       snap/microstack/current/: ./
 
-  kvm-support:
-    plugin: nil
-    stage-packages:
-    - try: [msr-tools]
-
   libvirt:
-    source: .
-    source-subdir: libvirt-1.3.1
+    source: https://libvirt.org/sources/libvirt-3.10.0.tar.xz
     plugin: autotools
     build-packages:
-    - libxml2-dev
-    - libxml-libxml-perl
-    - libcurl4-gnutls-dev
-    - libncurses5-dev
-    - libreadline-dev
-    - zlib1g-dev
-    - libgcrypt20-dev
-    - libgnutls28-dev
-    - libyajl-dev
-    - libpcap0.8-dev
-    - libaudit-dev
-    - libdevmapper-dev
-    - libpciaccess-dev
-    - libnl-3-dev
-    - libnl-route-3-dev
-    - uuid-dev
-    - try: [libnuma-dev]
-    - wget
-    - dpkg-dev
+      - libxml2-dev
+      - libcurl4-gnutls-dev
+      - libncurses5-dev
+      - libreadline-dev
+      - zlib1g-dev
+      - libgcrypt20-dev
+      - libgnutls28-dev
+      - libsasl2-dev
+      - libsanlock-dev
+      - libiscsi-dev
+      - librbd-dev
+      - librados-dev
+      - libyajl-dev
+      - libpcap0.8-dev
+      - libaudit-dev
+      - libdevmapper-dev
+      - libpciaccess-dev
+      - libnl-3-dev
+      - libnl-route-3-dev
+      - libpolkit-gobject-1-dev
+      - libxml2-utils
+      - uuid-dev
+      - libnuma-dev
+      - python-all
+      - python-six
+      - xsltproc
     stage-packages:
-    - try: [dmidecode]
-    - dnsmasq
-    - dnsmasq-utils
-    - ebtables
-    - libxml2
-    - libyajl2
-    - try: [libnuma1]
-    - libcurl3-gnutls
-    - libpciaccess0
+      - libxml2
+      - libyajl2
+      - libnuma1
+      - libcurl3-gnutls
+      - libpcap0.8
+      - libpciaccess0
+      - libsanlock-client1
     configflags:
-    - --with-qemu
-    - --without-bhyve
-    - --without-xen
-    - --without-openvz
-    - --without-vmware
-    - --without-xenapi
-    - --without-esx
-    - --without-hyperv
-    - --without-lxc
-    - --without-vz
-    - --without-vbox
-    - --without-uml
-    - --without-sasl
-    - --without-storage-iscsi
-    - --without-storage-sheepdog
-    - --without-storage-rbd
-    - --without-storage-lvm
-    - --without-selinux
-    - --prefix=/snap/$SNAPCRAFT_PROJECT_NAME/current
-    - --localstatedir=/var/snap/$SNAPCRAFT_PROJECT_NAME/common
-    - --sysconfdir=/var/snap/$SNAPCRAFT_PROJECT_NAME/common
-    - DNSMASQ=/snap/$SNAPCRAFT_PROJECT_NAME/current/usr/sbin/dnsmasq
-    - DMIDECODE=/snap/$SNAPCRAFT_PROJECT_NAME/current/usr/sbin/dmidecode
-    - OVSVSCTL=/snap/$SNAPCRAFT_PROJECT_NAME/current/bin/ovs-vsctl
-    - EBTABLES_PATH=/snap/$SNAPCRAFT_PROJECT_NAME/current/sbin/ebtables
-    - IPTABLES_PATH=/snap/$SNAPCRAFT_PROJECT_NAME/current/sbin/iptables
-    override-build: |
-      wget http://archive.ubuntu.com/ubuntu/pool/main/libv/libvirt/libvirt_1.3.1.orig.tar.gz
-      wget http://archive.ubuntu.com/ubuntu/pool/main/libv/libvirt/libvirt_1.3.1-1ubuntu10.25.debian.tar.xz
-      wget http://archive.ubuntu.com/ubuntu/pool/main/libv/libvirt/libvirt_1.3.1-1ubuntu10.25.dsc
-      dpkg-source -x libvirt*.dsc
-      snapcraftctl build
+        - --with-qemu
+        - --without-xen
+        - --without-openvz
+        - --without-vmware
+        - --without-xenapi
+        - --without-esx
+        - --without-hyperv
+        - --without-lxc
+        - --without-vz
+        - --without-vbox
+        - --without-uml
+        - --without-sasl
+        - --prefix=/snap/$SNAPCRAFT_PROJECT_NAME/current
+        - --localstatedir=/var/snap/$SNAPCRAFT_PROJECT_NAME/common
+        - --sysconfdir=/var/snap/$SNAPCRAFT_PROJECT_NAME/common
+        - DNSMASQ=/snap/$SNAPCRAFT_PROJECT_NAME/current/usr/sbin/dnsmasq
+        - DMIDECODE=/snap/$SNAPCRAFT_PROJECT_NAME/current/usr/sbin/dmidecode
+        - OVSVSCTL=/snap/$SNAPCRAFT_PROJECT_NAME/current/bin/ovs-vsctl
+        - EBTABLES_PATH=/snap/$SNAPCRAFT_PROJECT_NAME/current/sbin/ebtables
     organize:
       # Hack to shift installed libvirt back to root of snap
       # required to ensure that pathing to files etc works at
       # runtime
       # * is not used to avoid directory merge conflicts
       snap/microstack/current/: ./
+    filesets:
+      all:
+        - -etc/libvirt/libvirtd.conf
+    stage: [$all]
+    prime: [$all]
+
+  kvm-support:
+    plugin: nil
+    stage-packages:
+    - try: [msr-tools]
 
   # MySQL
   mysql-server:
@@ -733,13 +694,13 @@ parts:
   # Memcached Token Caching
   memcached:
     plugin: autotools
-    source: https://memcached.org/files/memcached-1.5.10.tar.gz
+    source: https://memcached.org/files/memcached-1.5.14.tar.gz
     build-packages:
       - libevent-dev
       - gcc
       - make
     stage-packages:
-      - libevent-2.0-5
+      - libevent-2.1-6
     override-build: |
       ./configure --prefix=$SNAPCRAFT_PART_INSTALL
       make
@@ -759,7 +720,7 @@ parts:
     source: https://www.kernel.org/pub/linux/utils/net/bridge-utils/bridge-utils-1.6.tar.gz
     plugin: autotools
   iproute2:
-    source: https://www.kernel.org/pub/linux/utils/net/iproute2/iproute2-4.9.0.tar.gz
+    source: https://www.kernel.org/pub/linux/utils/net/iproute2/iproute2-4.20.0.tar.gz
     plugin: autotools
     build-packages:
       - bison
@@ -773,7 +734,8 @@ parts:
     configflags:
       - --disable-nftables
       - --prefix=/snap/$SNAPCRAFT_PROJECT_NAME/current
-    install: |
+    override-build: |
+      snapcraftctl build
       cp --remove-destination $SNAPCRAFT_PART_INSTALL/snap/$SNAPCRAFT_PROJECT_NAME/current/sbin/xtables-multi \
         $SNAPCRAFT_PART_INSTALL/snap/$SNAPCRAFT_PROJECT_NAME/current/bin/iptables-xml
     organize:
@@ -800,6 +762,9 @@ parts:
 
   # Openstack Shared Parts
   overlay:
+    after:
+      - libvirt
+      - qemu
     plugin: dump
     source: snap-overlay
 

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -8,7 +8,12 @@ description: |
 grade: stable
 confinement: classic
 environment:
-  LD_LIBRARY_PATH: $SNAP/lib:$SNAP/lib/$SNAPCRAFT_ARCH_TRIPLET:$SNAP/usr/lib:$SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET
+  # Gather to gether core18 lib paths, so that we can append it to
+  # LD_LIBRARY_PATH below. If we don't do this, I believe that we
+  # clobber access to the core libs, and run into trouble w/ the snap
+  # reaching outside core to get stuff.
+  CORE18_LIB_PATH: /snap/core18/current/lib:/snap/core18/current/lib/$SNAPCRAFT_ARCH_TRIPLET:/snap/core18/current/usr/lib:/snap/core18/current/usr/lib/$SNAPCRAFT_ARCH_TRIPLET
+  LD_LIBRARY_PATH: $SNAP/lib:$SNAP/lib/$SNAPCRAFT_ARCH_TRIPLET:$SNAP/usr/lib:$SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET:$CORE18_LIB_PATH
   PATH: $SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$PATH
   LC_ALL: C
   OS_PLACEMENT_CONFIG_DIR: $SNAP/etc/nova/

--- a/tests/basic-test.sh
+++ b/tests/basic-test.sh
@@ -42,9 +42,6 @@ fi
 multipass exec $MACHINE -- \
           sudo snap install --classic --dangerous microstack*.snap
 
-# Run configure script!
-#multipass exec $MACHINE -- sudo microstack.configure
-
 # Run microstack.launch
 multipass exec $MACHINE -- /snap/bin/microstack.launch breakfast
 

--- a/tests/basic-test.sh
+++ b/tests/basic-test.sh
@@ -8,11 +8,14 @@ set -ex
 # installing the locally built snap. This will help verify that we
 # aren't breaking snaps in the wild with a change.
 UPGRADE_FROM="none"
-while getopts u: option
+DISTRO=18.04
+
+while getopts u:d: option
 do
     case "${option}"
     in
         u) UPGRADE_FROM=${OPTARG};;
+        d) DISTRO=${OPTARG};;
     esac
 done
 
@@ -25,8 +28,7 @@ if [ ! -f microstack_rocky_amd64.snap ]; then
    exit 1
 fi
 
-MACHINE=$(petname)
-DISTRO=18.04
+MACHINE=$(petname);
 
 # Launch a machine and copy the snap to it.
 multipass launch --cpus 2 --mem 16G $DISTRO --name $MACHINE

--- a/tests/basic-test.sh
+++ b/tests/basic-test.sh
@@ -42,6 +42,9 @@ fi
 multipass exec $MACHINE -- \
           sudo snap install --classic --dangerous microstack*.snap
 
+# Run configure script!
+#multipass exec $MACHINE -- sudo microstack.configure
+
 # Run microstack.launch
 multipass exec $MACHINE -- /snap/bin/microstack.launch breakfast
 


### PR DESCRIPTION
Giving the snapcraft.yaml a base property helps tremendously with the
efficiency of the build process, and I believe that it puts us in a
better position to reliably support non Ubuntu distros going forward.

This also bases us on long supported bionic libraries, and gives us a
nice place to work from as we add Python 3 and Stein support, as well
as general polish and fixes.