### PR TITLE
Use non-standard ports for keystone and nginx to avoid conflicts with pre-installed software

### DIFF
--- a/snap-overlay/bin/configure-openstack
+++ b/snap-overlay/bin/configure-openstack
@@ -11,9 +11,9 @@ systemctl restart snap.microstack.keystone-*
 openstack user show admin || {
     snap-openstack keystone-manage bootstrap \
         --bootstrap-password $OS_PASSWORD \
-        --bootstrap-admin-url http://10.20.20.1:5000/v3/ \
-        --bootstrap-internal-url http://10.20.20.1:5000/v3/ \
-        --bootstrap-public-url http://10.20.20.1:5000/v3/ \
+        --bootstrap-admin-url http://10.20.20.1:15000/v3/ \
+        --bootstrap-internal-url http://10.20.20.1:15000/v3/ \
+        --bootstrap-public-url http://10.20.20.1:15000/v3/ \
         --bootstrap-region-id microstack
 }
 

--- a/snap-overlay/etc/glance/glance.conf.d/keystone.conf
+++ b/snap-overlay/etc/glance/glance.conf.d/keystone.conf
@@ -1,6 +1,6 @@
 [keystone_authtoken]
-auth_uri = http://10.20.20.1:5000
-auth_url = http://10.20.20.1:5000
+auth_uri = http://10.20.20.1:15000
+auth_url = http://10.20.20.1:15000
 memcached_servers = 10.20.20.1:11211
 auth_type = password
 project_domain_name = default

--- a/snap-overlay/etc/neutron/neutron.conf.d/keystone.conf
+++ b/snap-overlay/etc/neutron/neutron.conf.d/keystone.conf
@@ -2,8 +2,8 @@
 auth_strategy = keystone
 
 [keystone_authtoken]
-auth_uri = http://10.20.20.1:5000
-auth_url = http://10.20.20.1:5000
+auth_uri = http://10.20.20.1:15000
+auth_url = http://10.20.20.1:15000
 memcached_servers = 10.20.20.1:11211
 auth_type = password
 project_domain_name = default

--- a/snap-overlay/etc/neutron/neutron.conf.d/nova.conf
+++ b/snap-overlay/etc/neutron/neutron.conf.d/nova.conf
@@ -3,7 +3,7 @@ notify_nova_on_port_status_changes = True
 notify_nova_on_port_data_changes = True
 
 [nova]
-auth_url = http://10.20.20.1:5000
+auth_url = http://10.20.20.1:15000
 auth_type = password
 project_domain_name = default
 user_domain_name = default

--- a/snap-overlay/etc/nova/nova.conf.d/keystone.conf
+++ b/snap-overlay/etc/nova/nova.conf.d/keystone.conf
@@ -1,6 +1,6 @@
 [keystone_authtoken]
-auth_uri = http://10.20.20.1:5000
-auth_url = http://10.20.20.1:5000
+auth_uri = http://10.20.20.1:15000
+auth_url = http://10.20.20.1:15000
 memcached_servers = 10.20.20.1:11211
 auth_type = password
 project_domain_name = default

--- a/snap-overlay/etc/nova/nova.conf.d/neutron.conf
+++ b/snap-overlay/etc/nova/nova.conf.d/neutron.conf
@@ -1,6 +1,6 @@
 [neutron]
 url = http://10.20.20.1:9696
-auth_url = http://10.20.20.1:5000
+auth_url = http://10.20.20.1:15000
 memcached_servers = 10.20.20.1:11211
 auth_type = password
 project_domain_name = default

--- a/snap-overlay/etc/nova/nova.conf.d/nova-placement.conf
+++ b/snap-overlay/etc/nova/nova.conf.d/nova-placement.conf
@@ -4,6 +4,6 @@ project_domain_name = default
 project_name = service
 auth_type = password
 user_domain_name = default
-auth_url = http://10.20.20.1:5000
+auth_url = http://10.20.20.1:15000
 username = placement
 password = placement

--- a/snap-overlay/lib/python2.7/site-packages/openstack_dashboard/local/local_settings.py
+++ b/snap-overlay/lib/python2.7/site-packages/openstack_dashboard/local/local_settings.py
@@ -185,7 +185,7 @@ EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 #]
 
 OPENSTACK_HOST = "127.0.0.1"
-OPENSTACK_KEYSTONE_URL = "http://%s:5000/v3" % OPENSTACK_HOST
+OPENSTACK_KEYSTONE_URL = "http://%s:15000/v3" % OPENSTACK_HOST
 OPENSTACK_KEYSTONE_DEFAULT_ROLE = "_member_"
 
 # For setting the default service region on a per-endpoint basis. Note that the

--- a/snap-overlay/templates/horizon-nginx.conf.j2
+++ b/snap-overlay/templates/horizon-nginx.conf.j2
@@ -2,7 +2,7 @@
 # to define this template. Be sure to update "listen" with the port number and
 # also update "api-name" for the socket.
 server {
-    listen 80;
+    listen 8080;
     access_log {{ snap_common }}/log/nginx-access.log;
     error_log {{ snap_common }}/log/nginx-error.log;
     location / {

--- a/snap-overlay/templates/keystone-nginx.conf.j2
+++ b/snap-overlay/templates/keystone-nginx.conf.j2
@@ -1,5 +1,5 @@
 server {
-    listen 5000;
+    listen 15000;
     access_log {{ snap_common }}/log/nginx-access.log;
     error_log {{ snap_common }}/log/nginx-error.log;
     location / {

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -20,6 +20,9 @@ for db in neutron nova nova_api nova_cell0 cinder glance keystone; do
         | mysql-start-client -u root
 done
 
+echo "update endpoint set url = REPLACE(url, 'http://localhost:5000/v3/', 'http://localhost:15000/v3/');" \
+        | mysql-start-client -u root keystone
+
 # Grant nova user access to cell0
 echo "GRANT ALL PRIVILEGES ON nova_cell0.* TO 'nova'@'10.20.20.1' IDENTIFIED BY 'nova';" | mysql-start-client -u root
 
@@ -48,7 +51,7 @@ while ! nc -z 10.20.20.1 9292; do sleep 0.1; done;
 sleep 5
 
 # Wait for identity service
-while ! nc -z 10.20.20.1 5000; do sleep 0.1; done;
+while ! nc -z 10.20.20.1 15000; do sleep 0.1; done;
 
 # Setup the cirros image, which is used by the launch app
 openstack image show cirros || {
@@ -64,4 +67,4 @@ openstack image show cirros || {
 }
 
 # Wait for horizon
-while ! nc -z 10.20.20.1 80; do sleep 0.1; done;
+while ! nc -z 10.20.20.1 8080; do sleep 0.1; done;

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -612,8 +612,8 @@ parts:
       - --target-list=x86_64-softmmu
     override-build: |
       wget http://archive.ubuntu.com/ubuntu/pool/main/q/qemu/qemu_2.5+dfsg.orig.tar.xz
-      wget http://archive.ubuntu.com/ubuntu/pool/main/q/qemu/qemu_2.5+dfsg-5ubuntu10.38.debian.tar.xz
-      wget http://archive.ubuntu.com/ubuntu/pool/main/q/qemu/qemu_2.5+dfsg-5ubuntu10.38.dsc
+      wget http://archive.ubuntu.com/ubuntu/pool/main/q/qemu/qemu_2.5+dfsg-5ubuntu10.39.debian.tar.xz
+      wget http://archive.ubuntu.com/ubuntu/pool/main/q/qemu/qemu_2.5+dfsg-5ubuntu10.39.dsc
       dpkg-source -x qemu_*.dsc
       snapcraftctl build
     organize:
@@ -691,8 +691,8 @@ parts:
     - IPTABLES_PATH=/snap/$SNAPCRAFT_PROJECT_NAME/current/sbin/iptables
     override-build: |
       wget http://archive.ubuntu.com/ubuntu/pool/main/libv/libvirt/libvirt_1.3.1.orig.tar.gz
-      wget http://archive.ubuntu.com/ubuntu/pool/main/libv/libvirt/libvirt_1.3.1-1ubuntu10.25.debian.tar.xz
-      wget http://archive.ubuntu.com/ubuntu/pool/main/libv/libvirt/libvirt_1.3.1-1ubuntu10.25.dsc
+      wget http://archive.ubuntu.com/ubuntu/pool/main/libv/libvirt/libvirt_1.3.1-1ubuntu10.26.debian.tar.xz
+      wget http://archive.ubuntu.com/ubuntu/pool/main/libv/libvirt/libvirt_1.3.1-1ubuntu10.26.dsc
       dpkg-source -x libvirt*.dsc
       snapcraftctl build
     organize:

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -17,7 +17,7 @@ environment:
   OS_PROJECT_NAME: admin
   OS_USERNAME: admin
   OS_PASSWORD: keystone
-  OS_AUTH_URL: http://10.20.20.1:5000
+  OS_AUTH_URL: http://10.20.20.1:15000
   OS_IDENTITY_API_VERSION: 3
   OS_IMAGE_API_VERSION: 2
 

--- a/src/launch/launch.sh
+++ b/src/launch/launch.sh
@@ -64,4 +64,4 @@ while :; do
     fi
 done
 
-echo "You can also visit the openstack dashboard at 'http://10.20.20.1/'"
+echo "You can also visit the openstack dashboard at 'http://10.20.20.1:8080/'"


### PR DESCRIPTION
Next steps would be to enable port configuration using hooks.